### PR TITLE
added getAssetUrl so it will pull domain prefix from env and add it t…

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -33,6 +33,10 @@ import { useServiceWorker } from './hooks/useServiceWorker';
 import { usePageVisibility, useBatteryStatus } from './hooks/useBrowserFeatures';
 import PWAInstallPrompt from './components/PWAInstallPrompt';
 
+// dynamically resolve domain for assets
+import { getAssetUrl } from './utils/getAssetUrl';
+
+
 // Code splitting: Lazy load page components
 const AccessibilityPage = lazy(() => import('./components/AccessibilityPage'));
 const PrivacyPage = lazy(() => import('./pages/PrivacyPage'));
@@ -195,7 +199,7 @@ const RoCafeSection = () => {
           <div className="md:w-1/2 w-full">
             <div className="relative aspect-square rounded-full overflow-hidden border-8 border-white/5 shadow-2xl">
                <img 
-                 src="/rocafe-logo.png" 
+                 src={getAssetUrl('/rocafe-logo.png')}
                  alt="RoCafe"
                  className="w-full h-full object-cover hover:scale-110 transition-transform duration-700"
                  loading="lazy"

--- a/src/utils/getAssetUrl.js
+++ b/src/utils/getAssetUrl.js
@@ -1,0 +1,20 @@
+// src/utils/getAssetUrl.js
+
+/**
+ * Returns a path for static assets, optionally prefixing with /<env-domain>/
+ * Example:
+ * - VITE_APP_DOMAIN = "romamart.ca"
+ *   getAssetUrl("/rocafe-logo.png") => "/romamart.ca/rocafe-logo.png"
+ * - VITE_APP_DOMAIN not set:
+ *   getAssetUrl("/rocafe-logo.png") => "/rocafe-logo.png"
+ */
+export function getAssetUrl(path) {
+    const domain = import.meta.env.VITE_APP_DOMAIN;
+    const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+    if (domain) {
+      // Always prefix with a slash, never double it
+      return `/${domain.replace(/^\//, '').replace(/\/$/, '')}${normalizedPath}`;
+    }
+    return normalizedPath;
+  }
+  


### PR DESCRIPTION
### check out the convention
This pull request introduces a utility for dynamically resolving asset URLs based on the deployment domain, improving compatibility with different hosting environments. The main changes include the addition of the `getAssetUrl` function and its integration into the app for loading static assets.

**Dynamic asset URL resolution:**

* Added a new utility function `getAssetUrl` in `src/utils/getAssetUrl.js` to prefix asset paths with the value of `VITE_APP_DOMAIN` if set, ensuring correct asset loading across domains.
* Updated the RoCafe logo image source in `src/App.jsx` to use `getAssetUrl` instead of a hardcoded path, making asset resolution dynamic.

**Code organization:**

* Imported `getAssetUrl` into `src/App.jsx` to enable usage of the new dynamic asset path logic.