### PR TITLE
chore(deps): add dependabot grouping rules and remove stale overrides

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,20 +6,46 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 15
     labels:
       - "dependencies"
       - "chore"
     commit-message:
       prefix: "chore(deps)"
+    groups:
+      dev-tooling:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+      commitlint:
+        patterns:
+          - "@commitlint/*"
     ignore:
+      # React 18 — intentional; no major upgrade planned
       - dependency-name: "react"
         update-types: ["version-update:semver-major"]
       - dependency-name: "react-dom"
         update-types: ["version-update:semver-major"]
+      # Tailwind v4 — full rewrite, defer indefinitely
       - dependency-name: "tailwindcss"
         update-types: ["version-update:semver-major"]
+      # hCaptcha v2 — evaluate later
       - dependency-name: "@hcaptcha/react-hcaptcha"
+        update-types: ["version-update:semver-major"]
+      # plugin-react v6 requires Vite 8 — incompatible with Vite 7
+      - dependency-name: "@vitejs/plugin-react"
+        update-types: ["version-update:semver-major"]
+      # lucide-react v1 — planned migration branch needed (icon renames)
+      - dependency-name: "lucide-react"
+        update-types: ["version-update:semver-major"]
+      # Vitest 4 + jsdom 29 — planned test toolchain upgrade branch
+      - dependency-name: "vitest"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "jsdom"
+        update-types: ["version-update:semver-major"]
+      # Vite 8 — planned major migration
+      - dependency-name: "vite"
         update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,8 @@ updates:
     groups:
       dev-tooling:
         dependency-type: "development"
+        exclude-patterns:
+          - "@commitlint/*"
         update-types:
           - "minor"
           - "patch"

--- a/package.json
+++ b/package.json
@@ -60,10 +60,6 @@
     "vitest": "^3.2.4"
   },
   "overrides": {
-    "react-helmet-async": {
-      "react": "^19.2.0",
-      "react-dom": "^19.2.0"
-    },
     "esbuild": "0.27.0"
   },
   "legacy-peer-deps": true,


### PR DESCRIPTION
## Description

Post-audit Dependabot policy cleanup and stale override removal.

### Changes

**`dependabot.yml`:**
- Raised `open-pull-requests-limit` from 10 to 15 (prevents queue starvation)
- Added `groups.dev-tooling` — collapses all dev minor/patch updates into one PR
- Added `groups.commitlint` — groups `@commitlint/*` packages (always released together)
- Added `ignore` rules for majors not ready to adopt:
  - `@vitejs/plugin-react` v6 (requires Vite 8, incompatible with current Vite 7)
  - `lucide-react` v1 (needs planned icon migration branch)
  - `vitest` v4 + `jsdom` v29 (test toolchain upgrade, planned branch)
  - `vite` v8 (major migration, planned separately)

**`package.json`:**
- Removed stale `react-helmet-async` peer-dep override — v3 (merged in PR #186) supports React 18 natively, so the override forcing React 19 peers is no longer needed

### Context

Part of the Dependabot audit that also:
- Merged PRs #193 (postcss), #187 (commitlint/cli), #188 (stylelint), #192 (framer-motion), #186 (react-helmet-async v3)
- Closed PRs #185, #189, #190, #194 via `@dependabot ignore this major version`
- PR #191 (commitlint/config-conventional) awaiting Dependabot rebase after merge conflict from #187

### Verification
- `npm install` clean (0 vulnerabilities)
- `npm run lint` passes
- `npm test` — 21 files, 335 tests passing
- `npm run check:quality` + `npm run check:integrity` pass (0 critical/high issues)
- Pre-commit hooks all passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to improve update grouping and control.
  * Adjusted dependency version resolution to support broader compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->