### PR TITLE
2.8.0 chore(dx): console audit, SW hook split, indexedDB null fix

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,18 +2,19 @@
 
 ## Project Overview
 
-Roma Mart 2.0 is a **React 18.3.1 + Vite 7** progressive web app for a multi-location convenience store chain. Built with accessibility-first, dark-mode-native, and quality-enforced architecture.
+Roma Mart 2.0 is a **React 18.3.1 + Vite 8** progressive web app for a multi-location convenience store chain. Built with accessibility-first, dark-mode-native, and quality-enforced architecture.
 
-**Stack:** React 18.3.1, Vite 7, Tailwind CSS, Framer Motion, ESM modules
+**Stack:** React 18.3.1, Vite 8, Tailwind CSS, Framer Motion, ESM modules
 **Deployment:** GitHub Pages (staging), custom domain (production)
+**Version:** 2.8.0
 
-### Current Status (Feb 2026)
+### Current Status (Apr 2026)
 
-An expert-consolidated audit identified 56 problems and produced 55 recommendations organized into 8 sprints (all complete). See planning documents for details:
-- **[docs/archive/ROADMAP.md](../docs/archive/ROADMAP.md)** -- Sprint plan, phase breakdown, domain scorecard (archived)
-- **[docs/archive/EXPERT_AUDIT_FEB_2026.md](../docs/archive/EXPERT_AUDIT_FEB_2026.md)** -- Full audit findings and recommendations (R1-R55) (archived)
-- **[docs/API_MIGRATION_READINESS.md](../docs/API_MIGRATION_READINESS.md)** -- Backend API spec for @Fern-Ali
-- **GitHub Issues:** #98-#106 (sprint issues), #107 (backend API), tracked on [RomaMart UI Roadmap](https://github.com/orgs/roma-mart/projects/4) project board
+8-sprint audit roadmap complete. Codebase is post-audit stable. Key references:
+- **[docs/archive/ROADMAP.md](../docs/archive/ROADMAP.md)** -- Sprint plan, R1-R55 (archived)
+- **[docs/archive/EXPERT_AUDIT_FEB_2026.md](../docs/archive/EXPERT_AUDIT_FEB_2026.md)** -- Full audit findings (archived)
+- **[docs/API_MIGRATION_READINESS.md](../docs/API_MIGRATION_READINESS.md)** -- Backend API spec
+- **GitHub Issue #107** -- Services & Locations APIs pending backend; tracked on [RomaMart UI Roadmap](https://github.com/orgs/roma-mart/projects/4)
 
 ## Critical Architecture Principles
 
@@ -156,7 +157,9 @@ npm run preview                # Preview production build
 - Cache bounded by `MAX_CACHE_ENTRIES = 100` with `trimCache()` eviction
 - `CACHE_VERSION` in `sw.js` controls cache invalidation — bump when changing caching behavior
 - `self.skipWaiting()` is user-controlled via message handler only (not auto-called on install)
-- **Hooks:** `useServiceWorker()` from `src/hooks/useServiceWorker.js` — returns `{ registration, updateAvailable, skipWaiting, isOnline }`
+- **Hooks:**
+  - `useServiceWorker()` (`src/hooks/useServiceWorker.js`) — returns `{ registration, updateAvailable, skipWaiting }`. Used in `App.jsx` only. Runs full SW lifecycle: registration, hourly update polling, controllerchange reload.
+  - `useIsOnline()` (`src/hooks/useIsOnline.js`) — returns a boolean. Used in `NetworkStatus.jsx` only. Thin online/offline listener. **Never use `useServiceWorker` in a component that only needs `isOnline`** — each call registers its own SW lifecycle, causing duplicate registrations.
 - **Components:**
   - `PWAInstallPrompt` — engagement-based install prompt with focus trap, persists install state to localStorage
   - `PWAUpdatePrompt` — persistent update notification card, wired in App.jsx with `updateAvailable`/`skipWaiting` from useServiceWorker
@@ -419,13 +422,14 @@ import { SERVICES } from '../data/services';
 ## Development Tooling & Code Style
 
 ### Code Formatting
-- **No Prettier configured** - Manual formatting following ESLint rules
+- **Prettier** configured — `npm run format` / `npm run format:check`. Runs automatically on staged files via lint-staged.
 - **EditorConfig:** `.editorconfig` configured (2-space indent, LF line endings, UTF-8, trailing whitespace trimming)
 - **ESLint:** Strict rules enforced via `npm run lint`
   - React Hooks compliance required
   - JSX accessibility (a11y) required
-  - No unused variables, no console.log in production code
-- **lint-staged:** Runs ESLint on `*.{js,jsx}` and Stylelint on `*.css` for staged files only (faster pre-commit)
+  - No unused variables
+  - **Only `console.warn` and `console.error` are allowed** — `console.log` is banned. All diagnostic calls must be wrapped: `if (import.meta.env.DEV) console.warn(...)`. Production builds must be silent.
+- **lint-staged:** Runs Prettier then ESLint on `*.{js,jsx}`, Prettier then Stylelint on `*.css`, Prettier on `*.json`
 - **commitlint:** Enforces [Conventional Commits](https://www.conventionalcommits.org/) format via `.husky/commit-msg` hook
 
 ### Git Workflow
@@ -453,7 +457,7 @@ import { SERVICES } from '../data/services';
 - **Maintenance** (`.github/ISSUE_TEMPLATE/maintenance.yml`) - Chore tasks, dependency updates, tooling improvements
 
 ### Testing Strategy
-- **Vitest test suite:** 12 test files, 154 tests (schema validation, utilities, hooks)
+- **Vitest test suite:** 21 test files, 339 tests (schema validation, utilities, hooks, contexts)
 - Quality also enforced via:
   1. ESLint + Stylelint (syntax & patterns)
   2. Universal quality checker (`check-quality.js` - 1000+ rules)
@@ -529,11 +533,11 @@ This file is the Copilot-specific project context. A parallel `CLAUDE.md` exists
 - When updating project conventions, architecture, or workflows, update BOTH files
 - Each file is optimized for its respective AI's context format
 - If you notice drift between the files, flag it and propose corrections
-- Last synced: February 12, 2026
+- Last synced: April 20, 2026
 
 ---
 
-**Last Updated:** February 12, 2026
+**Last Updated:** April 20, 2026
 **Maintained by:** GitHub Copilot & Claude Code (keep in sync with `CLAUDE.md`)
-**Codebase Version:** React 18.3.1 + Vite 7 (ESM)
-**API Status:** Menu API live (200 OK); Services & Locations APIs pending (#107) -- frontend uses static fallback
+**Codebase Version:** React 18.3.1 + Vite 8 (ESM)
+**API Status:** Menu API live (200 OK); Services & Locations APIs pending (#107) — frontend uses static fallback

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,18 +6,18 @@
 ## Project Overview
 
 **App:** Roma Mart 2.0 -- React PWA for a multi-location convenience store chain (Sarnia, ON)
-**Stack:** React 18.3.1, Vite 7, Tailwind CSS 3.4, Framer Motion, ESM modules
+**Stack:** React 18.3.1, Vite 8, Tailwind CSS 3.4, Framer Motion, ESM modules
 **Deployment:** GitHub Pages (staging at `https://roma-mart.github.io/romamart.ca/`), custom domain (production)
-**Version:** 2.7.1 (see Versioning Convention below)
+**Version:** 2.8.0 (see Versioning Convention below)
 **Repo:** `roma-mart/romamart.ca`
 
-### Current Status (Feb 2026)
+### Current Status (Apr 2026)
 
-An expert-consolidated audit (9 domain experts, 56 findings, 55 recommendations) drove an 8-sprint roadmap (all complete). Key docs:
-- `docs/archive/ROADMAP.md` -- Sprint plan, recommendations R1-R55, domain scorecard (archived)
+8-sprint audit roadmap complete. Codebase is post-audit stable. Key references:
+- `docs/archive/ROADMAP.md` -- Sprint plan, R1-R55 (archived)
 - `docs/archive/EXPERT_AUDIT_FEB_2026.md` -- Full audit findings (archived)
 - `docs/API_MIGRATION_READINESS.md` -- Backend API spec
-- GitHub Issues #98-#106 (sprint issues), #107 (backend API)
+- GitHub Issue #107 -- Services & Locations APIs (pending backend)
 - Project board: RomaMart UI Roadmap (GitHub Projects)
 
 ---
@@ -32,6 +32,7 @@ An expert-consolidated audit (9 domain experts, 56 findings, 55 recommendations)
 6. **All changes must pass `npm run check:all`** before commit (lint + quality + integrity).
 7. **No suppressed warnings.** Fix root causes. Systems over spot fixes.
 8. **Read before modifying.** Always read existing code and relevant docs before proposing changes.
+9. **Console logging pattern.** ESLint only permits `console.warn` and `console.error`. All diagnostic calls must be wrapped: `if (import.meta.env.DEV) console.warn(...)`. Production builds must be silent. `ErrorBoundary.jsx` is the only intentional production `console.error` (last-resort observability).
 
 ---
 
@@ -175,7 +176,7 @@ Accessibility, dark mode, performance, security, SEO, code quality, responsive d
 ## Testing
 
 **Framework:** Vitest
-**Tests:** 260 passing (as of v2.6.7)
+**Tests:** 339 passing (as of v2.8.0)
 **Coverage thresholds:** statements 60%, branches 50%, functions 60%, lines 60%
 
 ### Test Locations
@@ -285,7 +286,8 @@ Sprint templates are defined in `docs/archive/ROADMAP.md` under Sprint Plan.
 - **Caching:** Network-first for HTML/API, cache-first for static assets
 - **Cache bounded:** `MAX_CACHE_ENTRIES = 100` with `trimCache()` eviction
 - **`CACHE_VERSION`** controls cache invalidation
-- **Hook:** `useServiceWorker()` returns `{ registration, updateAvailable, skipWaiting, isOnline }`
+- **Hook:** `useServiceWorker()` returns `{ registration, updateAvailable, skipWaiting }` — used in `App.jsx` only
+- **Hook:** `useIsOnline()` (`src/hooks/useIsOnline.js`) returns a boolean — used in `NetworkStatus.jsx` only. Keep these separate: `useServiceWorker` runs the full SW lifecycle (registration, update polling, controllerchange); `useIsOnline` is a thin online/offline listener. Never call `useServiceWorker` from a component that only needs `isOnline`.
 - **Components:** `PWAInstallPrompt` (engagement-based), `PWAUpdatePrompt` (update notification)
 
 ---
@@ -305,6 +307,7 @@ Sprint templates are defined in `docs/archive/ROADMAP.md` under Sprint Plan.
 | `src/config/company_data.js` | Company info SSOT |
 | `src/config/navigation.js` | Navigation links SSOT |
 | `src/utils/theme.js` | Theme utilities, CSS variable helpers |
+| `src/hooks/useIsOnline.js` | Online/offline boolean hook (used by NetworkStatus only) |
 | `src/utils/api.js` | Centralized API utility (apiUrl, fetchWithEtag, ETag caching) |
 | `src/utils/apiCircuitBreaker.js` | API protection pattern |
 | `scripts/check-quality.js` | Universal quality checker |
@@ -323,10 +326,10 @@ This file (`CLAUDE.md`) is the Claude Code project context. A parallel `.github/
 - When updating project conventions, architecture, or workflows, update BOTH files
 - Each file is optimized for its respective AI's context format
 - If you notice drift between the files, flag it and propose corrections
-- Last synced: February 9, 2026
+- Last synced: April 20, 2026
 
 ---
 
-**Last Updated:** February 12, 2026
+**Last Updated:** April 20, 2026
 **Maintained by:** Claude Code (keep in sync with `.github/copilot-instructions.md`)
-**Codebase Version:** React 18.3.1 + Vite 7 (ESM)
+**Codebase Version:** React 18.3.1 + Vite 8 (ESM)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,7 +161,7 @@ npm run build              # Production build + prerender
 Accessibility, dark mode, performance, security, SEO, code quality, responsive design, browser compatibility, brand consistency.
 
 ### Git Hooks (Husky v9)
-- **pre-commit:** lint-staged (ESLint on `*.{js,jsx}`, Stylelint on `*.css`) + check:quality + check:integrity
+- **pre-commit:** lint-staged (Prettier on `*.{js,jsx,css,json}`, ESLint on `*.{js,jsx}`, Stylelint on `*.css`) + check:quality + check:integrity
 - **commit-msg:** commitlint (Conventional Commits)
 
 ### Pre-Commit Checklist

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > Modern PWA for Sarnia's premier convenience store chain
 
 [![React](https://img.shields.io/badge/React-18.3.1-61dafb)](https://react.dev/)
-[![Vite](https://img.shields.io/badge/Vite-7-646cff)](https://vitejs.dev/)
+[![Vite](https://img.shields.io/badge/Vite-8-646cff)](https://vitejs.dev/)
 [![WCAG 2.2 AA](https://img.shields.io/badge/WCAG-2.2%20AA-green)](https://www.w3.org/TR/WCAG22/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
 
@@ -61,7 +61,7 @@ See [Architecture](./docs/ARCHITECTURE.md) and [Quality System](./docs/QUALITY_S
 | Technology | Purpose |
 |------------|---------|
 | React 18.3.1 | UI framework |
-| Vite 7 | Build tool |
+| Vite 8 | Build tool |
 | Tailwind CSS | Styling |
 | Framer Motion | Animations |
 | ESM Modules | JavaScript modules |

--- a/src/components/CurrentLocalTime.jsx
+++ b/src/components/CurrentLocalTime.jsx
@@ -1,9 +1,9 @@
 /**
  * CurrentLocalTime Component
- * 
+ *
  * Displays the current local time for a given location.
  * Updates every second to show real-time clock.
- * 
+ *
  * @param {Object} props
  * @param {Object} props.location - Location object with timezone info
  * @returns {JSX.Element}
@@ -30,19 +30,19 @@ function CurrentLocalTime({ location }) {
         // Create formatter for location's timezone
         // Default to 'America/Toronto' if no timezone specified
         const timezone = location?.timezone || 'America/Toronto';
-        
+
         const formatter = new Intl.DateTimeFormat('en-CA', {
           timeZone: timezone,
           hour: '2-digit',
           minute: '2-digit',
           second: '2-digit',
-          hour12: true
+          hour12: true,
         });
 
         const formatted = formatter.format(new Date());
         setCurrentTime(formatted);
       } catch (error) {
-        console.error('Error formatting local time:', error);
+        if (import.meta.env.DEV) console.warn('[CurrentLocalTime] Invalid timezone or date format:', error.message);
         setCurrentTime('');
       }
     };
@@ -73,8 +73,8 @@ function CurrentLocalTime({ location }) {
 CurrentLocalTime.propTypes = {
   location: PropTypes.shape({
     timezone: PropTypes.string,
-    name: PropTypes.string
-  })
+    name: PropTypes.string,
+  }),
 };
 
 export default CurrentLocalTime;

--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -20,14 +20,14 @@ class ErrorBoundary extends React.Component {
 
   componentDidCatch(error, errorInfo) {
     this.setState({ errorInfo });
-    console.error('ErrorBoundary caught:', error);
+    console.error('[ErrorBoundary] Caught unhandled error:', error?.message || error);
     if (import.meta.env.DEV) {
       console.error('Component stack:', errorInfo.componentStack);
     }
     window.dataLayer?.push({
       event: 'error',
       error_message: error?.toString(),
-      error_source: 'ErrorBoundary'
+      error_source: 'ErrorBoundary',
     });
   }
 
@@ -50,7 +50,9 @@ class ErrorBoundary extends React.Component {
               className="w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-6"
               style={{ backgroundColor: 'var(--color-error-bg, var(--color-surface))' }}
             >
-              <span className="text-3xl" aria-hidden="true">!</span>
+              <span className="text-3xl" aria-hidden="true">
+                !
+              </span>
             </div>
             <h2
               className="text-xl font-bold mb-2"
@@ -71,16 +73,10 @@ class ErrorBoundary extends React.Component {
               Try refreshing the page or go back to the home page.
             </p>
             <div className="flex gap-3 justify-center">
-              <Button
-                variant="inverted"
-                onClick={this.handleReload}
-              >
+              <Button variant="inverted" onClick={this.handleReload}>
                 Refresh Page
               </Button>
-              <Button
-                variant="secondary"
-                href={import.meta.env.BASE_URL || "/"}
-              >
+              <Button variant="secondary" href={import.meta.env.BASE_URL || '/'}>
                 Go Home
               </Button>
             </div>

--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -20,7 +20,7 @@ class ErrorBoundary extends React.Component {
 
   componentDidCatch(error, errorInfo) {
     this.setState({ errorInfo });
-    console.error('[ErrorBoundary] Caught unhandled error:', error?.message || error);
+    console.error('[ErrorBoundary] Caught unhandled error:', error);
     if (import.meta.env.DEV) {
       console.error('Component stack:', errorInfo.componentStack);
     }

--- a/src/components/NetworkStatus.jsx
+++ b/src/components/NetworkStatus.jsx
@@ -5,10 +5,10 @@
 
 import React from 'react';
 import { WifiOff, Wifi } from 'lucide-react';
-import { useServiceWorker } from '../hooks/useServiceWorker';
+import { useIsOnline } from '../hooks/useIsOnline';
 
 const NetworkStatus = () => {
-  const { isOnline } = useServiceWorker();
+  const isOnline = useIsOnline();
   const [showReconnected, setShowReconnected] = React.useState(false);
   const prevIsOnlineRef = React.useRef(isOnline);
 

--- a/src/components/StructuredData.jsx
+++ b/src/components/StructuredData.jsx
@@ -32,7 +32,7 @@ const StructuredData = ({ type = 'LocalBusiness', data = {} }) => {
         }
 
         if (!data.products || !Array.isArray(data.products)) {
-          console.warn('[StructuredData] ProductList - No valid products array');
+          if (import.meta.env.DEV) console.warn('[StructuredData] ProductList - No valid products array');
           return null;
         }
 
@@ -56,7 +56,8 @@ const StructuredData = ({ type = 'LocalBusiness', data = {} }) => {
         }
 
         if (productSchemas.length === 0) {
-          console.warn('[StructuredData] ProductList - All schemas filtered out (returned null)');
+          if (import.meta.env.DEV)
+            console.warn('[StructuredData] ProductList - All schemas filtered out (returned null)');
           return null;
         }
 

--- a/src/contexts/MenuContext.jsx
+++ b/src/contexts/MenuContext.jsx
@@ -97,7 +97,7 @@ export function MenuProvider({ children }) {
       return { items: menu, source: 'api', error: '' };
     } catch (err) {
       // Network error or other exception - use static fallback
-      console.error('[MenuContext] Failed to fetch menu data:', err);
+      if (import.meta.env.DEV) console.warn('[MenuContext] Failed to fetch menu data:', err.message);
       circuitBreakers.menu.recordFailure(err);
       return { items: STATIC_FALLBACK, source: 'static', error: err.message || 'Failed to load menu data' };
     }

--- a/src/contexts/MenuContext.jsx
+++ b/src/contexts/MenuContext.jsx
@@ -97,9 +97,10 @@ export function MenuProvider({ children }) {
       return { items: menu, source: 'api', error: '' };
     } catch (err) {
       // Network error or other exception - use static fallback
-      if (import.meta.env.DEV) console.warn('[MenuContext] Failed to fetch menu data:', err.message);
+      const errorMessage = err?.message || String(err || '') || 'Failed to load menu data';
+      if (import.meta.env.DEV) console.warn('[MenuContext] Failed to fetch menu data:', errorMessage);
       circuitBreakers.menu.recordFailure(err);
-      return { items: STATIC_FALLBACK, source: 'static', error: err.message || 'Failed to load menu data' };
+      return { items: STATIC_FALLBACK, source: 'static', error: errorMessage };
     }
   }, []);
 

--- a/src/hooks/useIsOnline.js
+++ b/src/hooks/useIsOnline.js
@@ -1,0 +1,18 @@
+import { useState, useEffect } from 'react';
+
+export const useIsOnline = () => {
+  const [isOnline, setIsOnline] = useState(navigator.onLine);
+
+  useEffect(() => {
+    const handleOnline = () => setIsOnline(true);
+    const handleOffline = () => setIsOnline(false);
+    window.addEventListener('online', handleOnline);
+    window.addEventListener('offline', handleOffline);
+    return () => {
+      window.removeEventListener('online', handleOnline);
+      window.removeEventListener('offline', handleOffline);
+    };
+  }, []);
+
+  return isOnline;
+};

--- a/src/hooks/useServiceWorker.js
+++ b/src/hooks/useServiceWorker.js
@@ -50,7 +50,9 @@ export const useServiceWorker = () => {
           60 * 60 * 1000
         );
       } catch (error) {
-        if (import.meta.env.DEV) console.error('[SW] Registration failed:', error);
+        if (import.meta.env.DEV) {
+          console.error('[SW] Registration failed:', error);
+        }
       }
     };
 

--- a/src/hooks/useServiceWorker.js
+++ b/src/hooks/useServiceWorker.js
@@ -8,7 +8,6 @@ import { useEffect, useState } from 'react';
 export const useServiceWorker = () => {
   const [registration, setRegistration] = useState(null);
   const [updateAvailable, setUpdateAvailable] = useState(false);
-  const [isOnline, setIsOnline] = useState(navigator.onLine);
 
   useEffect(() => {
     let updateInterval;
@@ -18,7 +17,7 @@ export const useServiceWorker = () => {
     const registerServiceWorker = async () => {
       try {
         const reg = await navigator.serviceWorker.register('/sw.js', {
-          scope: '/'
+          scope: '/',
         });
 
         setRegistration(reg);
@@ -44,12 +43,14 @@ export const useServiceWorker = () => {
         });
 
         // Check for updates periodically (every hour)
-        updateInterval = setInterval(() => {
-          reg.update();
-        }, 60 * 60 * 1000);
-
+        updateInterval = setInterval(
+          () => {
+            reg.update();
+          },
+          60 * 60 * 1000
+        );
       } catch (error) {
-        console.error('[SW] Registration failed:', error);
+        if (import.meta.env.DEV) console.error('[SW] Registration failed:', error);
       }
     };
 
@@ -81,18 +82,9 @@ export const useServiceWorker = () => {
       };
     }
 
-    // Online/offline status
-    const handleOnline = () => setIsOnline(true);
-    const handleOffline = () => setIsOnline(false);
-
-    window.addEventListener('online', handleOnline);
-    window.addEventListener('offline', handleOffline);
-
     return () => {
       if (updateInterval) clearInterval(updateInterval);
       if (cleanupControllerChange) cleanupControllerChange();
-      window.removeEventListener('online', handleOnline);
-      window.removeEventListener('offline', handleOffline);
     };
   }, []);
 
@@ -106,6 +98,5 @@ export const useServiceWorker = () => {
     registration,
     updateAvailable,
     skipWaiting,
-    isOnline
   };
 };

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -47,6 +47,18 @@ if (GTM_ID) {
   document.body.insertBefore(noscript, document.body.firstChild);
 }
 
+window.addEventListener('unhandledrejection', (event) => {
+  if (import.meta.env.DEV) {
+    console.error('[App] Unhandled promise rejection:', event.reason);
+  } else {
+    window.dataLayer?.push({
+      event: 'error',
+      error_message: event.reason?.message || String(event.reason),
+      error_source: 'unhandledrejection',
+    });
+  }
+});
+
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <HelmetProvider>

--- a/src/utils/indexedDB.js
+++ b/src/utils/indexedDB.js
@@ -29,7 +29,7 @@ export const initDB = () => {
       if (!db.objectStoreNames.contains(STORE_NAME)) {
         const objectStore = db.createObjectStore(STORE_NAME, {
           keyPath: 'id',
-          autoIncrement: true
+          autoIncrement: true,
         });
 
         // Create indexes
@@ -53,7 +53,7 @@ export const queueFormSubmission = async (formData) => {
     const submission = {
       ...formData,
       timestamp: Date.now(),
-      synced: false
+      synced: false,
     };
 
     const request = store.add(submission);
@@ -95,6 +95,10 @@ export const markAsSynced = async (id) => {
 
     getRequest.onsuccess = () => {
       const data = getRequest.result;
+      if (!data) {
+        reject(new Error(`markAsSynced: record not found for id=${id}`));
+        return;
+      }
       data.synced = true;
       data.syncedAt = Date.now();
 
@@ -112,7 +116,7 @@ export const markAsSynced = async (id) => {
  */
 export const cleanupOldSubmissions = async () => {
   const db = await initDB();
-  const sevenDaysAgo = Date.now() - (7 * 24 * 60 * 60 * 1000);
+  const sevenDaysAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
 
   return new Promise((resolve, reject) => {
     const transaction = db.transaction([STORE_NAME], 'readwrite');
@@ -125,12 +129,12 @@ export const cleanupOldSubmissions = async () => {
       const cursor = event.target.result;
       if (cursor) {
         const item = cursor.value;
-        
+
         // Delete if synced and older than 7 days
         if (item.synced && item.timestamp < sevenDaysAgo) {
           cursor.delete();
         }
-        
+
         cursor.continue();
       } else {
         resolve();
@@ -155,5 +159,5 @@ export default {
   getPendingSubmissions,
   markAsSynced,
   cleanupOldSubmissions,
-  getPendingCount
+  getPendingCount,
 };


### PR DESCRIPTION
## Summary

- **Console audit** — all diagnostic `console` calls wrapped in `import.meta.env.DEV` guards; production builds are now fully silent (7 call-sites across 5 files fixed)
- **SW hook split** — extracted `useIsOnline` from `useServiceWorker` to eliminate 4× SW registration (NetworkStatus + App.jsx + StrictMode double-invoke)
- **Bug fix** — `markAsSynced` in `indexedDB.js` now null-checks `getRequest.result` before access; previously crashed with TypeError when record id not found
- **Observability** — global `unhandledrejection` handler added to `main.jsx`: DEV logs to console, production pushes to GA4 `dataLayer`
- **Docs** — CLAUDE.md, copilot-instructions.md, README synced to v2.8.0 / Vite 8 / 339 tests; console logging rule documented; `useIsOnline` documented

## Changes

| File | Change |
|------|--------|
| `src/hooks/useIsOnline.js` | **New** — thin online/offline boolean hook |
| `src/hooks/useServiceWorker.js` | Remove `isOnline` state + listeners; DEV-guard registration failure; warn→log level fix |
| `src/components/NetworkStatus.jsx` | Switch from `useServiceWorker` to `useIsOnline` |
| `src/utils/indexedDB.js` | Null-check `getRequest.result` in `markAsSynced` |
| `src/main.jsx` | Add global `unhandledrejection` handler |
| `src/contexts/MenuContext.jsx` | DEV-guard catch block console.error → console.warn |
| `src/components/CurrentLocalTime.jsx` | DEV-guard Intl error |
| `src/components/ErrorBoundary.jsx` | Improve production error message format |
| `src/components/StructuredData.jsx` | DEV-guard two ProductList validation warns |
| `CLAUDE.md` | Sync: v2.8.0, Vite 8, 339 tests, useIsOnline, console rule |
| `.github/copilot-instructions.md` | Sync: same + Prettier fix, test count, SW hooks |
| `README.md` | Vite 7 → 8 badge |

## Test plan

- [x] `npm run check:all` passes (lint + quality + integrity)
- [x] 339 tests pass (`npm run test`)
- [x] Pre-commit hooks passed (lint-staged + quality + integrity)
- [ ] Verify production build console is silent (`npm run build && npm run preview` → DevTools Console shows 0 app errors/warns)
- [ ] Confirm NetworkStatus still updates online/offline state correctly
- [ ] Confirm PWA update prompt still works (App.jsx `updateAvailable`/`skipWaiting` unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added global unhandled promise rejection reporting
  * Added a dedicated online/offline status hook for more reliable network indicators

* **Bug Fixes**
  * Standardized error handling with development-only console diagnostics

* **Refactor**
  * Separated service worker lifecycle from online/offline detection to avoid duplicate registrations

* **Chores**
  * Bumped project version to 2.8.0 and upgraded to Vite 8
  * Adopted Prettier formatting and tightened console logging rules

* **Documentation / Tests**
  * Updated docs and testing metrics (tests increased substantially)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->